### PR TITLE
Created FloodgateMenu.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,10 @@
             <id>minecraft-repo</id>
             <url>https://libraries.minecraft.net/</url>
         </repository>
+        <repository>
+            <id>opencollab-snapshot</id>
+            <url>https://repo.opencollab.dev/maven-snapshots/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -102,6 +106,12 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>23.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geysermc.floodgate</groupId>
+            <artifactId>api</artifactId>
+            <version>2.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/games/negative/framework/gui/floodgate/FloodgateMenu.java
+++ b/src/main/java/games/negative/framework/gui/floodgate/FloodgateMenu.java
@@ -16,8 +16,9 @@ public class FloodgateMenu {
     private final String title;
     private ModalFormResponse response;
     private ModalForm form;
+
     /**
-     * Create a new floodgate menu!
+     * Create a new floodgate menu
      *
      * @param content The content of the menu
      * @param title The title of the menu

--- a/src/main/java/games/negative/framework/gui/floodgate/FloodgateMenu.java
+++ b/src/main/java/games/negative/framework/gui/floodgate/FloodgateMenu.java
@@ -68,4 +68,5 @@ public class FloodgateMenu {
     public void acknowledge() {
         responded = false;
     }
+
 }

--- a/src/main/java/games/negative/framework/gui/floodgate/FloodgateMenu.java
+++ b/src/main/java/games/negative/framework/gui/floodgate/FloodgateMenu.java
@@ -1,0 +1,70 @@
+package games.negative.framework.gui.floodgate;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.geysermc.cumulus.ModalForm;
+import org.geysermc.cumulus.response.ModalFormResponse;
+import org.geysermc.floodgate.api.FloodgateApi;
+import org.geysermc.floodgate.api.player.FloodgatePlayer;
+
+@Getter
+@Setter
+public class FloodgateMenu {
+
+    private final String content;
+    private boolean responded = false;
+    private final String title;
+    private ModalFormResponse response;
+    private ModalForm form;
+    /**
+     * Create a new floodgate menu!
+     *
+     * @param content The content of the menu
+     * @param title The title of the menu
+     * @param button1 Button 1
+     * @param button2 Button 2
+     */
+    public FloodgateMenu(String content, String title, String button1, String button2) {
+        this.content = content;
+        this.title = title;
+        this.form = ModalForm.builder()
+                .content(content)
+                .button1(button1)
+                .button2(button2)
+                .responseHandler((form1, responseData) -> {
+                    this.response = form1.parseResponse(responseData);
+                    responded = true;
+        }).build();
+    }
+
+    /**
+     * Shows the form to the specified player
+     * @param player The player you would like to show the form to
+     */
+    public void show(FloodgatePlayer player) {
+        player.sendForm(form);
+    }
+
+    /**
+     * Check if the player has responded
+     * @return true if the player has responded
+     */
+    public boolean hasResponded() {
+        return responded;
+    }
+
+    /**
+     * Get the response from the player
+     * @return the response from the player
+     * @throws Exception if they haven't responded yet!
+     */
+    public ModalFormResponse getResponse() throws Exception {
+        if (response == null) {
+            throw new Exception("There was no response!");
+        }
+        return response;
+    }
+    public void acknowledge() {
+        responded = false;
+    }
+}

--- a/src/main/java/games/negative/framework/gui/floodgate/FloodgateMenu.java
+++ b/src/main/java/games/negative/framework/gui/floodgate/FloodgateMenu.java
@@ -2,6 +2,7 @@ package games.negative.framework.gui.floodgate;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang.Validate;
 import org.geysermc.cumulus.ModalForm;
 import org.geysermc.cumulus.response.ModalFormResponse;
 import org.geysermc.floodgate.api.FloodgateApi;
@@ -59,10 +60,8 @@ public class FloodgateMenu {
      * @return the response from the player
      * @throws Exception if they haven't responded yet!
      */
-    public ModalFormResponse getResponse() throws Exception {
-        if (response == null) {
-            throw new Exception("There was no response!");
-        }
+    public ModalFormResponse getResponse()  {
+        Validate.notNull(response, "There was no response");
         return response;
     }
     public void acknowledge() {

--- a/src/main/java/games/negative/framework/gui/floodgate/FloodgateMenu.java
+++ b/src/main/java/games/negative/framework/gui/floodgate/FloodgateMenu.java
@@ -68,5 +68,4 @@ public class FloodgateMenu {
     public void acknowledge() {
         responded = false;
     }
-
 }


### PR DESCRIPTION
Added support for a floodgate menu, here is an example:

````java
    public void example() {
        FloodgateMenu menu = new FloodgateMenu("Welcome to our server!", "Hello!", "I am a button", "I am also a button :("); // Create the menu
        UUID uuid = UUID.randomUUID(); // Replace UUID#randomUUID with the player's UUID
        menu.show(FloodgateApi.getInstance().getPlayer(uuid)); // Show the menu to a player
        while (menu.hasResponded()) {
            menu.acknowledge();
            // do something
        } // This will not loop
    }