### PR TITLE
Converted to `Utils.color` in GUI classes

### DIFF
--- a/src/main/java/games/negative/framework/gui/DropperGUI.java
+++ b/src/main/java/games/negative/framework/gui/DropperGUI.java
@@ -3,6 +3,7 @@ package games.negative.framework.gui;
 import games.negative.framework.gui.base.MenuBase;
 import games.negative.framework.gui.holder.DropperGUIHolder;
 import games.negative.framework.gui.internal.MenuItem;
+import games.negative.framework.util.Utils;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
@@ -68,7 +69,7 @@ public class DropperGUI implements MenuBase {
      */
     public void open(@NotNull Player player) {
         DropperGUIHolder holder = new DropperGUIHolder(this);
-        Inventory inv = Bukkit.createInventory(holder, InventoryType.DROPPER, ChatColor.translateAlternateColorCodes('&', title));
+        Inventory inv = Bukkit.createInventory(holder, InventoryType.DROPPER, Utils.color(title));
 
         player.openInventory(inv);
         activeInventories.put(player, inv);

--- a/src/main/java/games/negative/framework/gui/GUI.java
+++ b/src/main/java/games/negative/framework/gui/GUI.java
@@ -28,6 +28,7 @@ package games.negative.framework.gui;
 import games.negative.framework.gui.base.MenuBase;
 import games.negative.framework.gui.holder.GUIHolder;
 import games.negative.framework.gui.internal.MenuItem;
+import games.negative.framework.util.Utils;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
@@ -105,7 +106,7 @@ public class GUI implements MenuBase {
     @Override
     public void open(@NotNull Player player) {
         GUIHolder holder = new GUIHolder(this);
-        Inventory inv = Bukkit.createInventory(holder, (9 * rows), ChatColor.translateAlternateColorCodes('&', title));
+        Inventory inv = Bukkit.createInventory(holder, (9 * rows), Utils.color(title));
 
         player.openInventory(inv);
         activeInventories.put(player, inv);

--- a/src/main/java/games/negative/framework/gui/HopperGUI.java
+++ b/src/main/java/games/negative/framework/gui/HopperGUI.java
@@ -28,6 +28,7 @@ package games.negative.framework.gui;
 import games.negative.framework.gui.base.MenuBase;
 import games.negative.framework.gui.holder.HopperGUIHolder;
 import games.negative.framework.gui.internal.MenuItem;
+import games.negative.framework.util.Utils;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
@@ -94,7 +95,7 @@ public class HopperGUI implements MenuBase {
      */
     public void open(@NotNull Player player) {
         HopperGUIHolder holder = new HopperGUIHolder(this);
-        Inventory inv = Bukkit.createInventory(holder, InventoryType.HOPPER, ChatColor.translateAlternateColorCodes('&', title));
+        Inventory inv = Bukkit.createInventory(holder, InventoryType.HOPPER, Utils.color(title));
 
         player.openInventory(inv);
         activeInventories.put(player, inv);


### PR DESCRIPTION
[contributing]: https://github.com/Negative-Games/Framework/blob/main/CONTRIBUTING.md

## Pull Request Etiquette

<!-- There are several guidelines you should follow in order for your 
Pull Request to be merged. 
--> 

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!-- It is sometimes better to include more changes in a single commit. 
If you find yourself having an overwhelming amount of commits, you can **rebase** your branch. 
--> 

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code)
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if 
this is a response to an issue --> 

Closes Issue: NaN

## Description

Converts all instances of `ChatColor.translateAlternateColorCodes` within GUI-related classes, to `Utils.color`